### PR TITLE
Remove "Debug slot" logs

### DIFF
--- a/src/routes/SimpleCalendar.svelte
+++ b/src/routes/SimpleCalendar.svelte
@@ -560,21 +560,21 @@
                 slotTime.toDateString() === startTime.toDateString();
 
             // Uncomment temporarily to debug specific slots
-            if ((hour === 9 || hour === 10 || hour === 11) && minute === 0) {
-                console.log(
-                    `Debug slot ${date.toDateString()} ${hour}:${minute}`,
-                    {
-                        booking: `${booking.id} (${new Date(booking.start_time).toLocaleString()})`,
-                        slotTime: slotTime.toLocaleString(),
-                        slotEndTime: slotEndTime.toLocaleString(),
-                        bookingStart: startTime.toLocaleString(),
-                        bookingEnd: endTime.toLocaleString(),
-                        isWithinTimeRange,
-                        isSameDay,
-                        matched: isWithinTimeRange && isSameDay,
-                    },
-                );
-            }
+            //if ((hour === 9 || hour === 10 || hour === 11) && minute === 0) {
+            //    console.log(
+            //        `Debug slot ${date.toDateString()} ${hour}:${minute}`,
+            //        {
+            //            booking: `${booking.id} (${new Date(booking.start_time).toLocaleString()})`,
+            //            slotTime: slotTime.toLocaleString(),
+            //            slotEndTime: slotEndTime.toLocaleString(),
+            //            bookingStart: startTime.toLocaleString(),
+            //            bookingEnd: endTime.toLocaleString(),
+            //            isWithinTimeRange,
+            //            isSameDay,
+            //            matched: isWithinTimeRange && isSameDay,
+            //        },
+            //    );
+            //}
 
             return isWithinTimeRange && isSameDay;
         });


### PR DESCRIPTION
This section prints up to 80,000 debug messages on page load, causing a delay on slower computers. There's also a comment saying it should be commented out in production.